### PR TITLE
[UPY-3] Modify upload_files return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# UpyloadThing
+# Upyloadthing
+
 [![Build Status](https://github.com/farmisen/upyloadthing/workflows/CI/badge.svg)](https://github.com/farmisen/upyloadthing/actions)
 [![PyPI version](https://badge.fury.io/py/upyloadthing.svg)](https://badge.fury.io/py/upyloadthing)
 [![Python Versions](https://img.shields.io/pypi/pyversions/upyloadthing.svg)](https://pypi.org/project/upyloadthing/)
 
-Python client for the [Uploadthing API](https://docs.uploadthing.com/api-reference/openapi-spec) - The easiest way to add file uploads to your Python application.
+Python client for the [uploadthing](https://docs.uploadthing.com/api-reference/openapi-spec) API - The easiest way to add file uploads to your Python application.
 
 ## Installation
 
@@ -29,7 +30,7 @@ with open("example.png", "rb") as f:
 
 The SDK can be configured using environment variables:
 
-- `UPLOADTHING_TOKEN` - Your UploadThing API token (required if not passed to UTApiOptions)
+- `UPLOADTHING_TOKEN` - Your uploadthing API token (required if not passed to UTApiOptions)
 - `UPLOADTHING_REGION` - Preferred upload region (optional, defaults to first available region found in the decoded token)
 
 ## Examples
@@ -102,6 +103,7 @@ except Exception as e:
 ### UTApi Methods
 
 All methods are defined in [`upyloadthing/client.py`](upyloadthing/client.py):
+
 - `upload_files(files)` - Upload one or more files
 - `delete_files(keys, key_type='file_key')` - Delete files by key or custom ID
 - `list_files(limit=None, offset=None)` - List uploaded files
@@ -110,6 +112,7 @@ All methods are defined in [`upyloadthing/client.py`](upyloadthing/client.py):
 ### Response Models
 
 All response models are defined in [`upyloadthing/schemas.py`](upyloadthing/schemas.py):
+
 - `UploadResult` - File upload result containing:
   - `ufs_url: str`
   - `url: str`

--- a/examples/main.py
+++ b/examples/main.py
@@ -36,12 +36,11 @@ def main():
     upload_result: UploadResult = api.upload_files(
         image_file, acl="public-read"
     )  # type: ignore
-    file_key = upload_result.url.split("/")[-1]
     print(f"File uploaded with result: {upload_result}\n")
 
     # Delete the uploaded file
     print("🗑️ Deleting test file...")
-    delete_result = api.delete_files(file_key)
+    delete_result = api.delete_files(upload_result.file_key)
     print(f"Deleted {delete_result.deleted_count} file(s)")
     print(f"Success: {delete_result.success}\n")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,7 +84,14 @@ def test_upload_files(responses, ut_api, mock_file):
 
     result = ut_api.upload_files(mock_file)
 
+    # Verify result is correct type
     assert isinstance(result, UploadResult)
+
+    # Verify all fields
+    assert result.file_key is not None  # Generated dynamically
+    assert result.name == "test.jpg"
+    assert result.size == len(b"test content")
+    assert result.type == "image/jpeg"
     assert result.file_hash == "dae427dff5fa285fc87a791dc8b7daf1"
     assert (
         result.url
@@ -98,6 +105,7 @@ def test_upload_files(responses, ut_api, mock_file):
         result.app_url
         == "https://utfs.io/a/lhdsot44oz/AlZ3KvVUSx6sMzg3ZDRmZmM5NTRhNDBkMmI5ZWQ5ODg2NWZmODc3MTg="
     )
+    assert result.server_data is None  # Default value from schema
 
 
 def test_upload_multiple_files(responses, ut_api):

--- a/upyloadthing/client.py
+++ b/upyloadthing/client.py
@@ -202,7 +202,15 @@ class UTApi:
                     )
                 },
             )
-            results.append(UploadResult(**result))
+
+            upload_result = UploadResult(
+                file_key=file_data["file_key"],
+                name=file_data["name"],
+                size=file_data["size"],
+                type=file_data["type"],
+                **result,
+            )
+            results.append(upload_result)
 
         return results[0] if len(results) == 1 else results
 

--- a/upyloadthing/schemas.py
+++ b/upyloadthing/schemas.py
@@ -42,8 +42,12 @@ class UsageInfoResponse(BaseModel):
 
 
 class UploadResult(BaseModel):
-    ufs_url: str
+    file_key: str
+    name: str
+    size: int
+    type: str
     url: str
+    ufs_url: str
     app_url: str
     file_hash: str
     server_data: Dict | None = None


### PR DESCRIPTION
Refactors upload result handling and improves documentation.

The changes enhance the UploadResult model, including file_key, name, size, and type. The example and tests are updated to align with the new UploadResult structure.

### Changes

The UploadResult schema in upyloadthing/schemas.py is updated to include file_key, name, size, and type, and the order of the fields have been changed. \
The upload_files method in upyloadthing/client.py now populates and returns the file_key, name, size, and type fields in the UploadResult object.\
The example in examples/main.py is modified to use upload_result.file_key instead of parsing the URL to delete the uploaded file.\
The test in tests/test_client.py is updated to verify the new fields in UploadResult.\
Minor documentation updates in README.md, including capitalization fixes and a small change to the description of environment variables.
### Impact

The behavior of the upload_files method now returns more detailed upload results.\
The change affects the UploadResult data model and its usage in the example and tests.\
There are no apparent breaking changes, as the file_key is now directly accessible.\
There are no apparent performance implications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated docs to consistently use “uploadthing” and refined the API reference with clearer operational descriptions.

- **New Features**
  - Introduced additional file operation capabilities, including enhanced uploading, deletion, listing, and usage information retrieval.

- **Refactor**
  - Streamlined the file deletion process for improved reliability and enhanced clarity in the instantiation of upload results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->