### PR TITLE
[UPY-8] Export classes and schemas from the top level

### DIFF
--- a/examples/async_main.py
+++ b/examples/async_main.py
@@ -2,8 +2,7 @@ import asyncio
 from io import BytesIO
 from typing import List
 
-from upyloadthing.async_client import AsyncUTApi
-from upyloadthing.schemas import UploadResult
+from upyloadthing import AsyncUTApi, UploadResult
 
 
 async def main():

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,8 +1,7 @@
 from io import BytesIO
 from typing import List
 
-from upyloadthing.client import UTApi
-from upyloadthing.schemas import UploadResult
+from upyloadthing import UploadResult, UTApi
 
 
 def main():

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -6,15 +6,15 @@ import httpx
 import pytest
 import respx
 
-from upyloadthing.async_client import AsyncUTApi
-from upyloadthing.base_client import API_URL
-from upyloadthing.schemas import (
+from upyloadthing import (
+    AsyncUTApi,
     DeleteFileResponse,
     ListFileResponse,
     UploadResult,
     UsageInfoResponse,
     UTApiOptions,
 )
+from upyloadthing.base_client import API_URL
 
 # Test data
 MOCK_TOKEN = base64.b64encode(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,15 +6,15 @@ import httpx
 import pytest
 import respx
 
-from upyloadthing.base_client import API_URL
-from upyloadthing.client import UTApi
-from upyloadthing.schemas import (
+from upyloadthing import (
     DeleteFileResponse,
     ListFileResponse,
     UploadResult,
     UsageInfoResponse,
+    UTApi,
     UTApiOptions,
 )
+from upyloadthing.base_client import API_URL
 
 # Test data
 MOCK_TOKEN = base64.b64encode(

--- a/upyloadthing/__init__.py
+++ b/upyloadthing/__init__.py
@@ -1,0 +1,23 @@
+from upyloadthing.async_client import AsyncUTApi
+from upyloadthing.client import UTApi
+from upyloadthing.schemas import (
+    DeleteFileResponse,
+    FileData,
+    ListFileResponse,
+    UploadResult,
+    UsageInfoResponse,
+    UTApiOptions,
+    UTtoken,
+)
+
+__all__ = [
+    "AsyncUTApi",
+    "UTApi",
+    "UTApiOptions",
+    "UTtoken",
+    "FileData",
+    "ListFileResponse",
+    "DeleteFileResponse",
+    "UsageInfoResponse",
+    "UploadResult",
+]


### PR DESCRIPTION
Added package-level imports via init.py to simplify client import statements

This change consolidates imports by exposing key classes and types at the package level through init.py. It simplifies how clients import components by reducing the need for deep imports from specific modules.

### Changes

- Created new init.py to expose public API components
- Consolidated imports in example files and test modules
- Moved schema and client class imports to package level

### Impact

- Simplified import statements for package users
- No functional changes to underlying code
- No breaking changes as all types remain accessible
- No performance impact as this is import organization only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated and reorganized module structure and public interface for improved clarity and maintainability, ensuring a more streamlined experience without affecting functionality.
  
- **Chores**
  - Updated test arrangements to align with the new organization, preserving all behaviors as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->