### PR TITLE
[UPY-13] Add file ACL update functionality with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ cython_debug/
 
 .envrc
 .vscode/settings.json
+.qodo/history.sqlite

--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ response = api.rename_files([
 ])
 ```
 
+### Update ACL Settings
+
+```python
+# Update ACL for specific files using file keys
+response = api.update_acl([
+    {"fileKey": "file_key_123", "acl": "private"},
+    {"fileKey": "file_key_456", "acl": "public-read"}
+])
+
+# Update ACL using custom IDs
+response = api.update_acl([
+    {"customId": "custom_123", "acl": "private"},
+    {"customId": "custom_456", "acl": "public-read"}
+])
+
+# Mix of file keys and custom IDs
+response = api.update_acl([
+    {"fileKey": "file_key_123", "acl": "private"},
+    {"customId": "custom_456", "acl": "public-read"}
+])
+```
+
 ### List Files
 
 ```python
@@ -165,6 +187,13 @@ Both clients provide these methods:
     - `newName` (required)  
   - Returns rename operation result  
 
+- `update_acl(updates: List[dict[str, str]]) -> UpdateACLResponse`
+  - Update ACL settings for one or more files
+  - Updates list should contain dicts with:
+    - Either `fileKey` or `customId` (one is required)
+    - `acl` (required, either 'public-read' or 'private')
+  - Returns ACL update operation result
+
 - `get_usage_info() -> UsageInfoResponse`
   - Get account usage statistics
   - Returns usage information
@@ -192,6 +221,9 @@ All response models are defined in `upyloadthing/schemas.py`:
 - `RenameFilesResponse` - File rename result containing:
   - `success: bool`
   - `renamed_count: int`
+- `UpdateACLResponse` - ACL update result containing:
+  - `success: bool`
+  - `updated_count: int`
 - `UsageInfoResponse` - Usage statistics containing:
   - `total_bytes: int`
   - `app_total_bytes: int`

--- a/examples/async_main.py
+++ b/examples/async_main.py
@@ -81,6 +81,17 @@ async def main():
         print(f"Found: {actual_names}")
     print()
 
+    # Update ACL test
+    print("🔒 Updating ACL settings...")
+    acl_updates = [
+        {"fileKey": upload_results[0].file_key, "acl": "public-read"},
+        {"fileKey": upload_results[1].file_key, "acl": "public-read"},
+    ]
+    acl_result = await api.update_acl(acl_updates)
+    print(f"Updated ACL for {len(acl_updates)} files")
+    print(f"Success: {acl_result.success}")
+    print(f"Updated count: {acl_result.updated_count}\n")
+
     # Delete the uploaded files
     print("🗑️ Deleting test files...")
     file_keys = [result.file_key for result in upload_results]

--- a/examples/main.py
+++ b/examples/main.py
@@ -70,6 +70,17 @@ def main():
         print(f"Found: {actual_names}")
     print()
 
+    # Update ACL test
+    print("🔒 Updating ACL settings...")
+    acl_updates = [
+        {"fileKey": upload_results[0].file_key, "acl": "public-read"},
+        {"fileKey": upload_results[1].file_key, "acl": "public-read"},
+    ]
+    acl_result = api.update_acl(acl_updates)
+    print(f"Updated ACL for {len(acl_updates)} files")
+    print(f"Success: {acl_result.success}")
+    print(f"Updated count: {acl_result.updated_count}\n")
+
     # Delete the uploaded files
     print("🗑️ Deleting test files...")
     file_keys = [result.file_key for result in upload_results]

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,10 +7,12 @@ import pytest
 import respx
 
 from upyloadthing import (
+    ACLValue,
     AsyncUTApi,
     DeleteFileResponse,
     ListFileResponse,
     RenameFilesResponse,
+    UpdateACLResponse,
     UploadResult,
     UsageInfoResponse,
     UTApiOptions,
@@ -197,7 +199,7 @@ async def test_upload_multiple_files_with_custom_disposition(
 @respx.mock
 async def test_delete_files(respx_mock: respx.MockRouter, ut_api):
     """Test file deletion."""
-    delete_response = {"success": True, "deleted_count": 1}
+    delete_response = {"success": True, "deletedCount": 1}
 
     respx_mock.post(f"{API_URL}/v6/deleteFiles").mock(
         return_value=httpx.Response(200, json=delete_response)
@@ -224,7 +226,7 @@ async def test_list_files(respx_mock: respx.MockRouter, ut_api):
                 "name": "test.jpg",
                 "status": "ready",
                 "size": 1024,
-                "uploaded_at": 1704067200,
+                "uploadedAt": 1704067200,
             }
         ],
     }
@@ -246,10 +248,10 @@ async def test_list_files(respx_mock: respx.MockRouter, ut_api):
 async def test_get_usage_info(respx_mock: respx.MockRouter, ut_api):
     """Test usage info retrieval."""
     usage_response = {
-        "total_bytes": 1024,
-        "app_total_bytes": 2048,
-        "files_uploaded": 10,
-        "limit_bytes": 5000000,
+        "totalBytes": 1024,
+        "appTotalBytes": 2048,
+        "filesUploaded": 10,
+        "limitBytes": 5000000,
     }
 
     respx_mock.post(f"{API_URL}/v6/getUsageInfo").mock(
@@ -268,7 +270,7 @@ async def test_get_usage_info(respx_mock: respx.MockRouter, ut_api):
 @respx.mock
 async def test_rename_files(respx_mock: respx.MockRouter, ut_api):
     """Test renaming files with new names."""
-    rename_response = {"success": True, "renamed_count": 2}
+    rename_response = {"success": True, "renamedCount": 2}
 
     respx_mock.post(f"{API_URL}/v6/renameFiles").mock(
         return_value=httpx.Response(200, json=rename_response)
@@ -291,7 +293,7 @@ async def test_rename_files_with_custom_id(
     respx_mock: respx.MockRouter, ut_api
 ):
     """Test renaming files with custom IDs."""
-    rename_response = {"success": True, "renamed_count": 2}
+    rename_response = {"success": True, "renamedCount": 2}
 
     respx_mock.post(f"{API_URL}/v6/renameFiles").mock(
         return_value=httpx.Response(200, json=rename_response)
@@ -314,7 +316,7 @@ async def test_rename_files_mixed_updates(
     respx_mock: respx.MockRouter, ut_api
 ):
     """Test renaming files with mixed update types (both new names and custom IDs)."""  # noqa: E501
-    rename_response = {"success": True, "renamed_count": 2}
+    rename_response = {"success": True, "renamedCount": 2}
 
     respx_mock.post(f"{API_URL}/v6/renameFiles").mock(
         return_value=httpx.Response(200, json=rename_response)
@@ -357,3 +359,128 @@ async def test_request_with_different_content_types(
 
     result = await ut_api._request("POST", "/test-json", {"data": "test"})
     assert result == {"key": "value"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_acl(respx_mock: respx.MockRouter, ut_api):
+    """Test updating ACL settings with file keys."""
+    acl_response = {"success": True, "updatedCount": 2}
+
+    respx_mock.post(f"{API_URL}/v6/updateACL").mock(
+        return_value=httpx.Response(200, json=acl_response)
+    )
+
+    updates = [
+        {"fileKey": "file_key_1", "acl": ACLValue.PRIVATE.value},
+        {"fileKey": "file_key_2", "acl": ACLValue.PUBLIC_READ.value},
+    ]
+
+    result = await ut_api.update_acl(updates)
+    assert isinstance(result, UpdateACLResponse)
+    assert result.success is True
+    assert result.updated_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_acl_with_custom_id(respx_mock: respx.MockRouter, ut_api):
+    """Test updating ACL settings with custom IDs."""
+    acl_response = {"success": True, "updatedCount": 2}
+
+    respx_mock.post(f"{API_URL}/v6/updateACL").mock(
+        return_value=httpx.Response(200, json=acl_response)
+    )
+
+    updates = [
+        {"customId": "custom_123", "acl": ACLValue.PRIVATE.value},
+        {"customId": "custom_456", "acl": ACLValue.PUBLIC_READ.value},
+    ]
+
+    result = await ut_api.update_acl(updates)
+    assert isinstance(result, UpdateACLResponse)
+    assert result.success is True
+    assert result.updated_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_acl_mixed_updates(respx_mock: respx.MockRouter, ut_api):
+    """Test updating ACL settings with mixed update types."""
+    acl_response = {"success": True, "updatedCount": 2}
+
+    respx_mock.post(f"{API_URL}/v6/updateACL").mock(
+        return_value=httpx.Response(200, json=acl_response)
+    )
+
+    updates = [
+        {"fileKey": "file_key_123", "acl": ACLValue.PRIVATE.value},
+        {"customId": "custom_456", "acl": ACLValue.PUBLIC_READ.value},
+    ]
+
+    result = await ut_api.update_acl(updates)
+    assert isinstance(result, UpdateACLResponse)
+    assert result.success is True
+    assert result.updated_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_acl_with_invalid_acl(
+    respx_mock: respx.MockRouter, ut_api
+):
+    """Test updating ACL settings with invalid ACL value."""
+    updates = [
+        {"fileKey": "file_key_1", "acl": "invalid-acl"},
+    ]
+
+    mock_post = respx_mock.post(f"{API_URL}/v6/updateACL").mock(
+        return_value=httpx.Response(400, json={"success": False})
+    )
+
+    with pytest.raises(
+        ValueError, match="ACL must be one of: 'public-read', 'private'"
+    ):
+        await ut_api.update_acl(updates)
+    assert not mock_post.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_acl_with_missing_acl(
+    respx_mock: respx.MockRouter, ut_api
+):
+    """Test updating ACL settings with missing ACL field."""
+    updates = [
+        {"fileKey": "file_key_1"},  # Missing acl field
+    ]
+
+    mock_post = respx_mock.post(f"{API_URL}/v6/updateACL").mock(
+        return_value=httpx.Response(400, json={"success": False})
+    )
+
+    with pytest.raises(ValueError, match="Missing 'acl' in update"):
+        await ut_api.update_acl(updates)
+    assert not mock_post.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_acl_with_missing_identifier(
+    respx_mock: respx.MockRouter, ut_api
+):
+    """Test updating ACL settings with missing identifier."""
+    updates = [
+        {"acl": ACLValue.PUBLIC_READ.value},  # Missing fileKey/customId
+    ]
+
+    mock_post = respx_mock.post(f"{API_URL}/v6/updateACL").mock(
+        return_value=httpx.Response(400, json={"success": False})
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Each update must contain either 'fileKey' or 'customId'",
+    ):
+        await ut_api.update_acl(updates)
+    assert not mock_post.called

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,7 @@ def test_snakify_non_dict_types():
     assert snakify(None) is None
     assert snakify(42) == 42
     assert snakify("someString") == "someString"
+    assert snakify("limitBytes") == "limitBytes"
     assert snakify(True) is True
     assert snakify([1, 2, 3]) == [1, 2, 3]
 
@@ -60,3 +61,20 @@ def test_snakify_empty_structures():
     assert snakify({}) == {}
     assert snakify([]) == []
     assert snakify([{}]) == [{}]
+
+
+def test_snakify_dict_other():
+    """Test dictionary key conversion."""
+    input_dict = {
+        "totalBytes": 1024,
+        "appTotalBytes": 2048,
+        "filesUploaded": 10,
+        "limitBytes": 5000000,
+    }
+    expected = {
+        "total_bytes": 1024,
+        "app_total_bytes": 2048,
+        "files_uploaded": 10,
+        "limit_bytes": 5000000,
+    }
+    assert snakify(input_dict) == expected

--- a/upyloadthing/__init__.py
+++ b/upyloadthing/__init__.py
@@ -1,10 +1,12 @@
 from upyloadthing.async_client import AsyncUTApi
 from upyloadthing.client import UTApi
 from upyloadthing.schemas import (
+    ACLValue,
     DeleteFileResponse,
     FileData,
     ListFileResponse,
     RenameFilesResponse,
+    UpdateACLResponse,
     UploadResult,
     UsageInfoResponse,
     UTApiOptions,
@@ -16,10 +18,12 @@ __all__ = [
     "UTApi",
     "UTApiOptions",
     "UTtoken",
+    "ACLValue",
     "FileData",
     "ListFileResponse",
     "RenameFilesResponse",
     "DeleteFileResponse",
     "UsageInfoResponse",
     "UploadResult",
+    "UpdateACLResponse",
 ]

--- a/upyloadthing/async_client.py
+++ b/upyloadthing/async_client.py
@@ -8,6 +8,7 @@ from upyloadthing.schemas import (
     DeleteFileResponse,
     ListFileResponse,
     RenameFilesResponse,
+    UpdateACLResponse,
     UploadResult,
     UsageInfoResponse,
 )
@@ -193,3 +194,23 @@ class AsyncUTApi(BaseUTApi):
             "POST", "/v6/renameFiles", {"updates": updates}
         )
         return RenameFilesResponse(**result)
+
+    async def update_acl(
+        self, updates: List[dict[str, str]]
+    ) -> UpdateACLResponse:
+        """Update ACL settings for one or more files asynchronously.
+
+        Args:
+            updates: List of update objects containing either:
+                    - fileKey and acl
+                    - customId and acl
+                    where acl must be a valid ACLValue
+
+        Returns:
+            UpdateACLResponse: Response containing update results
+        """
+        self._validate_acl_updates(updates)
+        result = await self._request(
+            "POST", "/v6/updateACL", {"updates": updates}
+        )
+        return UpdateACLResponse(**result)

--- a/upyloadthing/client.py
+++ b/upyloadthing/client.py
@@ -7,6 +7,7 @@ from upyloadthing.schemas import (
     DeleteFileResponse,
     ListFileResponse,
     RenameFilesResponse,
+    UpdateACLResponse,
     UploadResult,
     UsageInfoResponse,
 )
@@ -179,3 +180,19 @@ class UTApi(BaseUTApi):
         """
         result = self._request("POST", "/v6/renameFiles", {"updates": updates})
         return RenameFilesResponse(**result)
+
+    def update_acl(self, updates: List[dict[str, str]]) -> UpdateACLResponse:
+        """Update ACL settings for one or more files synchronously.
+
+        Args:
+            updates: List of update objects containing either:
+                    - fileKey and acl
+                    - customId and acl
+                    where acl must be a valid ACLValue
+
+        Returns:
+            UpdateACLResponse: Response containing update results
+        """
+        self._validate_acl_updates(updates)
+        result = self._request("POST", "/v6/updateACL", {"updates": updates})
+        return UpdateACLResponse(**result)

--- a/upyloadthing/schemas.py
+++ b/upyloadthing/schemas.py
@@ -1,6 +1,12 @@
+from enum import Enum
 from typing import Dict, List
 
 from pydantic import BaseModel
+
+
+class ACLValue(Enum):
+    PUBLIC_READ = "public-read"
+    PRIVATE = "private"
 
 
 class UTApiOptions(BaseModel):
@@ -46,6 +52,11 @@ class UsageInfoResponse(BaseModel):
     limit_bytes: int
 
 
+class UpdateACLResponse(BaseModel):
+    success: bool
+    updated_count: int
+
+
 class UploadResult(BaseModel):
     file_key: str
     name: str
@@ -56,3 +67,4 @@ class UploadResult(BaseModel):
     app_url: str
     file_hash: str
     server_data: Dict | None = None
+    acl: ACLValue | None = None


### PR DESCRIPTION
Add ACL (Access Control List) update functionality with corresponding tests and documentation

This change introduces a new API capability to modify access control settings for uploaded files, supporting both file keys and custom IDs. The implementation includes synchronous and asynchronous client methods, comprehensive test coverage, and documentation updates.

### Changes

- Added new update_acl() method to both sync and async API clients
- Implemented UpdateACLResponse schema class for ACL operation results
- Added comprehensive test coverage for ACL updates including different identifier types
- Updated README with new ACL update API documentation and examples
- Extended example scripts to demonstrate ACL functionality

### Impact

- Enhances file access control management capabilities
- Maintains backward compatibility with existing API functionality
- No breaking changes to existing interfaces
- Minimal performance impact - single API endpoint call per update operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to update file access permissions (public or private) after uploads.
  - Enhanced examples showcase both synchronous and asynchronous workflows for managing file permissions.

- **Documentation**
  - Updated the user guide with clear instructions and code examples on configuring file access settings.
  - Added new response types and method signatures to the documentation for better clarity on usage.

- **Tests**
  - Added multiple test cases to validate the functionality of updating Access Control List (ACL) settings.
  - Standardized response format in existing tests to ensure consistency.

- **Chores**
  - Updated `.gitignore` to exclude specific files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->